### PR TITLE
Added support for Python 3 and IDA Pro 7.4+ .. 8.3

### DIFF
--- a/classdiagram.py
+++ b/classdiagram.py
@@ -1,4 +1,4 @@
-from idaapi import GraphViewer, askfile_c
+from idaapi import GraphViewer, ask_file
 
 # The  below will only be displayed as bases
 ignore_namespaces = ("std", "type_info")
@@ -75,19 +75,20 @@ class ClassDiagram(GraphViewer):
     # dot file export modified from http://joxeankoret.com
     def OnCommand(self, cmd_id):
         if self.cmd_dot == cmd_id:
-            fname = askfile_c(1, "*.dot", "Export DOT file")
+            fname = ask_file(1, "*.dot", "Export DOT file")
             if fname:
-                f = open(fname, "wb")
+                f = open(fname, "wt")
                 buf = "digraph G {\n graph [overlap=scale]; node [fontname=Courier]; rankdir=\"LR\";\n\n"
-                for c in self.classes.keys():
-                    n = self.classes.keys().index(c)
+                keyList = list(self.classes.keys())
+                for c in keyList:
+                    n = keyList.index(c)
                     buf += ' a%s [shape=box, label = "%s", color="blue"]\n' % (n, c)
                 buf += "\n"
-                for c in self.classes.keys():
-                    class_index = self.classes.keys().index(c)
+                for c in keyList:
+                    class_index = keyList.index(c)
                     for base in self.classes[c]:
-                        if base in self.classes.keys():
-                            base_index = self.classes.keys().index(base)
+                        if base in keyList:
+                            base_index = keyList.index(base)
                             buf += ' a%s -> a%s [style = bold]\n' % (class_index, base_index)
                 buf += "}"
                 f.write(buf)

--- a/classinformer.py
+++ b/classinformer.py
@@ -5,13 +5,12 @@
 
 import idaapi
 from idc import *
-from idc_bc695 import *
 
 idaapi.require("utils")
 idaapi.require("msvc")
 idaapi.require("gcc")
 idaapi.require("classdiagram")
-from idaapi import autoIsOk
+from idaapi import auto_is_ok
 from msvc import run_msvc
 from gcc import run_gcc
 from classdiagram import ClassDiagram
@@ -21,13 +20,14 @@ def show_classes(classes):
     c.Show()
 
 def isGcc():
-    gcc_info = FindText(0x0, SEARCH_CASE|SEARCH_DOWN, 0, 0, "N10__cxxabiv117__class_type_infoE")
+    gcc_info = find_text(0x0, SEARCH_CASE|SEARCH_DOWN, 0, 0, "N10__cxxabiv117__class_type_infoE")
     return gcc_info != BADADDR
 
 def main():
     print("Starting ClassInformerPython")
-    if autoIsOk():
-        classes = run_gcc() if isGcc() else run_msvc()
+    if auto_is_ok():
+        classes = run_gcc()
+        #classes = run_gcc() if isGcc() else run_msvc()
         print(classes)
         show_classes(classes)
     else:

--- a/classinformer.py
+++ b/classinformer.py
@@ -5,6 +5,7 @@
 
 import idaapi
 from idc import *
+from ida_search import find_text
 
 idaapi.require("utils")
 idaapi.require("msvc")
@@ -20,14 +21,13 @@ def show_classes(classes):
     c.Show()
 
 def isGcc():
-    gcc_info = find_text(0x0, SEARCH_CASE|SEARCH_DOWN, 0, 0, "N10__cxxabiv117__class_type_infoE")
+    gcc_info = find_text(0x0, 0, 0, "N10__cxxabiv117__class_type_infoE", SEARCH_CASE|SEARCH_DOWN)
     return gcc_info != BADADDR
 
 def main():
     print("Starting ClassInformerPython")
     if auto_is_ok():
-        classes = run_gcc()
-        #classes = run_gcc() if isGcc() else run_msvc()
+        classes = run_gcc() if isGcc() else run_msvc()
         print(classes)
         show_classes(classes)
     else:

--- a/msvc.py
+++ b/msvc.py
@@ -152,7 +152,7 @@ def run_msvc():
     for offset in range(0, rdata_size-u.PTR_SIZE, u.PTR_SIZE):
         vtable = start+offset
         if u.isVtable(vtable):
-            print("vtable at : " + hex(vtable)[:-1])
+            print("vtable at : " + hex(vtable))
             col = u.get_ptr(vtable-u.PTR_SIZE)
             if u.within(col, u.valid_ranges):
                 rcol = RTTICompleteObjectLocator(col, vtable)

--- a/msvc.py
+++ b/msvc.py
@@ -1,7 +1,5 @@
-from idaapi import get_struc_id, BADADDR, del_struc, get_struc, add_struc, add_struc_member, FF_DATA, FF_DWRD, FF_0OFF, get_struc_size, FF_ASCI, do_unknown_range, DOUNK_DELNAMES, doStruct, get_member_by_name, get_32bit, get_ascii_contents, demangle_name, doDwrd, op_offset
+from idaapi import get_struc_id, BADADDR, del_struc, get_struc, add_struc, add_struc_member, FF_DATA, FF_DWORD, FF_0OFF, get_struc_size, FF_STRLIT, del_items, DELIT_DELNAMES, create_struct, get_member_by_name, get_32bit, get_strlit_contents, demangle_name, create_dword, op_offset
 from idc import *
-from idc_bc695 import *
-
 from utils import utils
 u = utils()
 
@@ -27,21 +25,21 @@ class RTTICompleteObjectLocator(RTTIStruc):
     if msid != BADADDR:
         del_struc(msid)
     msid = add_struc(0xFFFFFFFF, "RTTICompleteObjectLocator", False)
-    add_struc_member(msid, "signature", BADADDR, FF_DATA|FF_DWRD, -1, 4)
-    add_struc_member(msid, "offset", BADADDR, FF_DATA|FF_DWRD, -1, 4)
-    add_struc_member(msid, "cdOffset", BADADDR, FF_DATA|FF_DWRD, -1, 4)
-    add_struc_member(msid, "pTypeDescriptor", BADADDR, FF_DATA|FF_DWRD|FF_0OFF, u.mt_rva().tid, 4)
-    add_struc_member(msid, "pClassDescriptor", BADADDR, FF_DATA|FF_DWRD|FF_0OFF, u.mt_rva().tid, 4)
+    add_struc_member(msid, "signature", BADADDR, FF_DATA|FF_DWORD, -1, 4)
+    add_struc_member(msid, "offset", BADADDR, FF_DATA|FF_DWORD, -1, 4)
+    add_struc_member(msid, "cdOffset", BADADDR, FF_DATA|FF_DWORD, -1, 4)
+    add_struc_member(msid, "pTypeDescriptor", BADADDR, FF_DATA|FF_DWORD|FF_0OFF, u.mt_rva().tid, 4)
+    add_struc_member(msid, "pClassDescriptor", BADADDR, FF_DATA|FF_DWORD|FF_0OFF, u.mt_rva().tid, 4)
     if u.x64:
-        add_struc_member(msid, "pSelf", BADADDR, FF_DATA|FF_DWRD|FF_0OFF, u.mt_rva().tid, 4)
+        add_struc_member(msid, "pSelf", BADADDR, FF_DATA|FF_DWORD|FF_0OFF, u.mt_rva().tid, 4)
     tid = msid
     struc = get_struc(tid)
     size = get_struc_size(tid)
     print("Completed Registering RTTICompleteObjectLocator")
 
     def __init__(self, ea, vtable):
-        do_unknown_range(ea, self.size, DOUNK_DELNAMES)
-        if doStruct(ea, self.size, self.tid):
+        del_items(ea, DELIT_DELNAMES, self.size)
+        if ida_bytes.create_struct(ea, self.size, self.tid):
             # Get adress of type descriptor from CompleteLocator
             print("Complete Object Locator at: 0x%x" % ea)
             offset = get_member_by_name(self.struc, "pTypeDescriptor").soff
@@ -56,11 +54,11 @@ class RTTICompleteObjectLocator(RTTIStruc):
                 # filter out None entries
                 rchd.bases = filter(lambda x: x, rchd.bases)
                 classes[strip(rtd.class_name)] = [strip(b) for b in rchd.bases]
-                MakeNameEx(vtable, "vtable__" + strip(rtd.class_name), SN_NOWARN)
+                set_name(vtable, "vtable__" + strip(rtd.class_name), SN_NOWARN)
             else:
                 # if the RTTITypeDescriptor doesn't have a valid name for us to
                 # read, then this wasn't a valid RTTICompleteObjectLocator
-                MakeUnknown(ea, self.size, DOUNK_SIMPLE)
+                del_items(ea, self.size, DELIT_SIMPLE)
 
 class RTTITypeDescriptor(RTTIStruc):
     class_name = None
@@ -71,7 +69,7 @@ class RTTITypeDescriptor(RTTIStruc):
     msid = add_struc(0xFFFFFFFF, "RTTITypeDescriptor", False)
     add_struc_member(msid, "pVFTable", BADADDR, FF_DATA|u.PTR_TYPE|FF_0OFF, u.mt_address().tid, u.PTR_SIZE)
     add_struc_member(msid, "spare", BADADDR, FF_DATA|u.PTR_TYPE, -1, u.PTR_SIZE)
-    add_struc_member(msid, "name", BADADDR, FF_DATA|FF_ASCI, u.mt_ascii().tid, 0)
+    add_struc_member(msid, "name", BADADDR, FF_DATA|FF_STRLIT, u.mt_ascii().tid, 0)
     tid = msid
     struc = get_struc(tid)
     size = get_struc_size(tid)
@@ -84,15 +82,16 @@ class RTTITypeDescriptor(RTTIStruc):
             # not a real vtable
             return
         self.size = self.size + strlen
-        mangled = get_ascii_contents(name, strlen, 0)
-        if mangled is None:
+        bmangled = get_strlit_contents(name, strlen, 0)
+        if bmangled is None:
             # not a real function name
             return
+        mangled = bmangled.decode('UTF-8')
         print("Mangled: " + mangled)
         demangled = demangle_name('??_R0' + mangled[1:] , 0)
         if demangled:
-            do_unknown_range(ea, self.size, DOUNK_DELNAMES)
-            if doStruct(ea, self.size, self.tid):
+            del_items(ea, DELIT_DELNAMES, self.size)
+            if ida_bytes.create_struct(ea, self.size, self.tid):
                 print("  Made td at 0x%x: %s" % (ea, demangled))
                 self.class_name = demangled
                 return
@@ -106,18 +105,18 @@ class RTTIClassHierarchyDescriptor(RTTIStruc):
     if msid != BADADDR:
         del_struc(msid)
     msid = add_struc(0xFFFFFFFF, "RTTIClassHierarchyDescriptor", False)
-    add_struc_member(msid, "signature", BADADDR, FF_DWRD|FF_DATA, -1, 4)
-    add_struc_member(msid, "attribute", BADADDR, FF_DWRD|FF_DATA, -1, 4)
-    add_struc_member(msid, "numBaseClasses", BADADDR, FF_DWRD|FF_DATA, -1, 4)
-    add_struc_member(msid, "pBaseClassArray", BADADDR, FF_DATA|FF_DWRD|FF_0OFF, u.mt_rva().tid, 4)
+    add_struc_member(msid, "signature", BADADDR, FF_DWORD|FF_DATA, -1, 4)
+    add_struc_member(msid, "attribute", BADADDR, FF_DWORD|FF_DATA, -1, 4)
+    add_struc_member(msid, "numBaseClasses", BADADDR, FF_DWORD|FF_DATA, -1, 4)
+    add_struc_member(msid, "pBaseClassArray", BADADDR, FF_DATA|FF_DWORD|FF_0OFF, u.mt_rva().tid, 4)
     tid = msid
     struc = get_struc(tid)
     print("Completed Registering RTTIClassHierarchyDescriptor")
 
     def __init__(self, ea):
         print("Processing Class Hierarchy Descriptor at 0x%x" % ea)
-        do_unknown_range(ea, get_struc_size(self.tid), DOUNK_DELNAMES)
-        if doStruct(ea, get_struc_size(self.tid), self.tid):
+        del_items(ea, DELIT_DELNAMES, get_struc_size(self.tid))
+        if ida_bytes.create_struct(ea, get_struc_size(self.tid), self.tid):
             baseClasses = get_32bit(ea+get_member_by_name(get_struc(self.tid), "pBaseClassArray").soff) + u.x64_imagebase()
             nb_classes = get_32bit(ea+get_member_by_name(get_struc(self.tid), "numBaseClasses").soff)
             print("Baseclasses array at 0x%x" % baseClasses)
@@ -126,9 +125,9 @@ class RTTIClassHierarchyDescriptor(RTTIStruc):
             for i in range(1, nb_classes):
                 baseClass = get_32bit(baseClasses+i*4) + u.x64_imagebase()
                 print("base class 0x%x" % baseClass)
-                doDwrd(baseClasses+i*4, 4)
+                ida_bytes.create_dword(baseClasses+i*4, 4)
                 op_offset(baseClasses+i*4, -1, u.REF_OFF|REFINFO_RVA, -1, 0, 0)
-                doStruct(baseClass, RTTIBaseClassDescriptor.size, RTTIBaseClassDescriptor.tid)
+                ida_bytes.create_struct(baseClass, RTTIBaseClassDescriptor.size, RTTIBaseClassDescriptor.tid)
                 typeDescriptor = get_32bit(baseClass) + u.x64_imagebase()
                 self.bases.append(RTTITypeDescriptor(typeDescriptor).class_name)
 
@@ -137,18 +136,18 @@ class RTTIBaseClassDescriptor(RTTIStruc):
     if msid != BADADDR:
         del_struc(msid)
     msid = add_struc(0xFFFFFFFF, "RTTIBaseClassDescriptor", False)
-    add_struc_member(msid, "pTypeDescriptor", BADADDR, FF_DATA|FF_DWRD|FF_0OFF, u.mt_rva().tid, 4)
-    add_struc_member(msid, "numContainerBases", BADADDR, FF_DWRD|FF_DATA, -1, 4)
-    add_struc_member(msid, "PMD", BADADDR, FF_DATA|FF_DWRD|FF_0OFF, u.mt_rva().tid, 4)
-    add_struc_member(msid, "attributes", BADADDR, FF_DWRD|FF_DATA, -1, 4)
+    add_struc_member(msid, "pTypeDescriptor", BADADDR, FF_DATA|FF_DWORD|FF_0OFF, u.mt_rva().tid, 4)
+    add_struc_member(msid, "numContainerBases", BADADDR, FF_DWORD|FF_DATA, -1, 4)
+    add_struc_member(msid, "PMD", BADADDR, FF_DATA|FF_DWORD|FF_0OFF, u.mt_rva().tid, 4)
+    add_struc_member(msid, "attributes", BADADDR, FF_DWORD|FF_DATA, -1, 4)
     tid = msid
     struc = get_struc(tid)
     size = get_struc_size(tid)
     print("Completed Registering RTTIBaseClassDescriptor")
 
 def run_msvc():
-    start = u.rdata.startEA
-    end = u.rdata.endEA
+    start = u.rdata.start_ea
+    end = u.rdata.end_ea
     rdata_size = end-start
     for offset in range(0, rdata_size-u.PTR_SIZE, u.PTR_SIZE):
         vtable = start+offset


### PR DESCRIPTION
This commit is the _exact_ commit from @PsychoPast in PR#6, but adds the fix for the issue commented upon there.

Strictly speaking it doesn't just fix the issue in `main` which incapacitated the MSVC code path, but also adds two other fixes.

IDAPython in IDA 8.3 complains about `find_text` being deprecated in favor of `ida_search.find_text`. Additionally the EAs of the vtables were trimmed by one hex digit.

I'd suggest to use f-strings where possible in the future, but I'll only put in the work if one of the project owners deems this worthwhile as well.

PS: was a little difficult to scrape the original commit from this repo, but I managed it and added my minor changes on top. So this obviates the need for PR#6, if merged.