### PR TITLE
Minor update for IDA 7.7 and Python 3

### DIFF
--- a/classinformer.py
+++ b/classinformer.py
@@ -36,3 +36,5 @@ def main():
 
 if __name__ == '__main__':
     main()
+if __name__ == '__plugins__classinformer':
+    main()

--- a/utils.py
+++ b/utils.py
@@ -97,7 +97,7 @@ class utils(object):
         sv = struct.pack("<Q", val)
       else:
         sv = struct.pack("<I", val)
-      return " ".join("%02X" % ord(c) for c in sv)
+      return " ".join("%02X" % b for b in sv)
 
     def ptrfirst(self, val):
       return find_binary(0, SEARCH_CASE|SEARCH_DOWN, self.ptr_to_bytes(val))


### PR DESCRIPTION
Noticed that version 7.7 uses the script/plugins path as `__name__ `, and `struct.pack()` behaves differently between Python 2 and 3.